### PR TITLE
feat: add CLI dosage genotype mode

### DIFF
--- a/src/jaxqtl/cli.py
+++ b/src/jaxqtl/cli.py
@@ -33,6 +33,7 @@ from .infer import (
 )
 from .io import (
     ExpressionData,
+    GenotypeReadOptions,
     load_genotype_dataset,
     read_offset_tsvlike,
     read_plink_style_tsvlike,
@@ -83,6 +84,12 @@ def _create_common_subp(subp, name, help):
     geno_group.add_argument("--pfile", help="Prefix to PLINK2 PGEN/PVAR/PSAM triplets.")
     geno_group.add_argument("--vcf", help="Path to an indexed VCF/BCF genotype file.")
     geno_group.add_argument("--bgen", help="Path to a BGEN genotype file.")
+    common_p.add_argument(
+        "--dosage",
+        action="store_true",
+        default=False,
+        help="Read genotype dosages instead of hard calls.",
+    )
 
     # pheno / covariate arguments
     common_p.add_argument("--pheno", help="Path to phenotypes", required=True)
@@ -594,6 +601,7 @@ def _common_setup(args, log):
         offset,
         keep_samples=inds_to_keep,
         drop_samples=inds_to_exclude,
+        read_options=GenotypeReadOptions(dosage="dosage" if getattr(args, "dosage", False) else "hardcall"),
     )
     log.info("Finished reading and aligning genotype, phenotype, covariate data.")
 

--- a/tests/test_cli/test_genoio_cli.py
+++ b/tests/test_cli/test_genoio_cli.py
@@ -117,6 +117,7 @@ def _common_setup_args(cmd: str) -> SimpleNamespace:
         bgen=None,
         geno=None,
         vcf=None,
+        dosage=False,
         pheno="tutorial/input/CD4_NC.N100.bed.gz",
         covar="tutorial/input/donor_features.tsv",
         covar_name=None,
@@ -201,6 +202,30 @@ def test_cli_help_marks_legacy_genotype_inputs() -> None:
     assert "Prefix to PLINK2 PGEN/PVAR/PSAM triplets." in help_text
     assert "Path to an indexed VCF/BCF genotype file." in help_text
     assert "Path to a BGEN genotype file." in help_text
+
+
+def test_cli_help_exposes_dosage_genotype_mode() -> None:
+    stdout = StringIO()
+    with redirect_stdout(stdout), pytest.raises(SystemExit) as exc_info:
+        cli.main(["cis", "--help"])
+
+    assert exc_info.value.code == 0
+    help_text = " ".join(stdout.getvalue().split())
+    assert "--dosage" in help_text
+    assert "Read genotype dosages instead of hard calls." in help_text
+
+
+@pytest.mark.parametrize(
+    ("dosage", "expected_mode"),
+    [(False, "hardcall"), (True, "dosage")],
+)
+def test_common_setup_selects_genoio_genotype_mode(dosage: bool, expected_mode: str) -> None:
+    args = _common_setup_args("trans")
+    args.dosage = dosage
+
+    ready_data, _, _, _, _ = cli._common_setup(args, _LoggerStub())
+
+    assert ready_data.read_options.dosage == expected_mode
 
 
 @pytest.mark.parametrize("cmd", ["cis", "nominal"])

--- a/tests/test_io/test_genoio_engine.py
+++ b/tests/test_io/test_genoio_engine.py
@@ -12,7 +12,7 @@ import pytest
 import jax
 import jax.numpy as jnp
 
-from jaxqtl.io._geno_engine import filter_sample_ids, normalize_variant_info
+from jaxqtl.io._geno_engine import filter_sample_ids, GenotypeReadOptions, normalize_variant_info
 from jaxqtl.io._pheno import ExpressionData
 from jaxqtl.map.data import align_on_iid, CisData, ReadyDataState
 
@@ -197,6 +197,21 @@ def test_ready_data_state_aligns_to_genoio_source_order_and_uses_sample_pushdown
     assert variants.to_ir() == genoio.polymorphic().to_ir()
     assert isinstance(G, jax.Array)
     assert variant_info.get_column("snp").to_list() == ["rs1", "rs2"]
+
+
+def test_ready_data_state_passes_dosage_mode_to_genoio() -> None:
+    dataset = _SyntheticGenoioDataset()
+    covar = pl.DataFrame({"iid": ["iid1", "iid2", "iid3"], "cov": [1.0, 2.0, 3.0]})
+
+    ready = ReadyDataState.from_data(
+        cast(genoio.Dataset, dataset),
+        _expression(),
+        covar,
+        read_options=GenotypeReadOptions(dosage="dosage"),
+    )
+    next(ready.iter_geno(chunk_size=128))
+
+    assert dataset.block_calls[0][1]["dosage"] == "dosage"
 
 
 def test_ready_data_state_iter_cis_uses_genoio_regions_with_polymorphic_filter() -> None:


### PR DESCRIPTION
CLI now supports `--dosage`. Exceptions thrown for data-modes that do not support it (eg PLINK1).

Refs: https://github.com/mancusolab/jaxqtl/issues/25