### PR TITLE
feat(cli): add minimum MAF filtering

### DIFF
--- a/src/jaxqtl/cli.py
+++ b/src/jaxqtl/cli.py
@@ -202,6 +202,12 @@ def _create_common_subp(subp, name, help):
         default=0.0,
         help="Exclude genes expressed in fewer than specified percentage of individuals (e.g., '0.1')",
     )
+    common_p.add_argument(
+        "--maf",
+        type=float,
+        default=None,
+        help="Exclude variants with minor allele frequency below this threshold.",
+    )
     gene_group = common_p.add_mutually_exclusive_group()
     gene_group.add_argument(
         "--gene-list",
@@ -602,6 +608,7 @@ def _common_setup(args, log):
         keep_samples=inds_to_keep,
         drop_samples=inds_to_exclude,
         read_options=GenotypeReadOptions(dosage="dosage" if getattr(args, "dosage", False) else "hardcall"),
+        min_maf=args.maf,
     )
     log.info("Finished reading and aligning genotype, phenotype, covariate data.")
 

--- a/src/jaxqtl/io/_geno_engine.py
+++ b/src/jaxqtl/io/_geno_engine.py
@@ -58,9 +58,12 @@ def load_genotype_dataset(source: GenotypeSource, path: str) -> genoio.Dataset:
             raise ValueError(f"Unsupported genotype source: {source!r}")
 
 
-def default_variant_filter() -> genoio.FilterExpr:
-    """Default mapping filter: genoio handles monomorphic variants before return."""
-    return genoio.polymorphic()
+def default_variant_filter(*, min_maf: float | None = None) -> genoio.FilterExpr:
+    """Return the default mapping filter with an optional minimum MAF threshold."""
+    variant_filter = genoio.polymorphic()
+    if min_maf is not None:
+        variant_filter = variant_filter & genoio.maf(min=min_maf)
+    return variant_filter
 
 
 def region_filter(chrom: str, start: int, end: int, base_filter: genoio.FilterExpr) -> genoio.FilterExpr:

--- a/src/jaxqtl/map/data.py
+++ b/src/jaxqtl/map/data.py
@@ -166,6 +166,7 @@ class ReadyDataState:
         keep_samples: list[str] | None = None,
         drop_samples: list[str] | None = None,
         read_options: GenotypeReadOptions | None = None,
+        min_maf: float | None = None,
     ) -> "ReadyDataState":
         """Align genotype, expression, covariates, and optional offset on IID and return a ReadyDataState."""
         genotype_samples = _sample_frame(filter_sample_ids(genotype.samples(), keep=keep_samples, drop=drop_samples))
@@ -202,7 +203,7 @@ class ReadyDataState:
             covar=covar_array,
             offset=offset_array,
             read_options=read_options or GenotypeReadOptions(),
-            variant_filter=default_variant_filter(),
+            variant_filter=default_variant_filter(min_maf=min_maf),
         )
 
 

--- a/tests/test_cli/test_genoio_cli.py
+++ b/tests/test_cli/test_genoio_cli.py
@@ -5,6 +5,7 @@ from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 
+import genoio
 import polars as pl
 import pytest
 
@@ -118,6 +119,7 @@ def _common_setup_args(cmd: str) -> SimpleNamespace:
         geno=None,
         vcf=None,
         dosage=False,
+        maf=None,
         pheno="tutorial/input/CD4_NC.N100.bed.gz",
         covar="tutorial/input/donor_features.tsv",
         covar_name=None,
@@ -202,6 +204,20 @@ def test_cli_help_marks_legacy_genotype_inputs() -> None:
     assert "Prefix to PLINK2 PGEN/PVAR/PSAM triplets." in help_text
     assert "Path to an indexed VCF/BCF genotype file." in help_text
     assert "Path to a BGEN genotype file." in help_text
+    assert "--maf" in help_text
+
+
+def test_common_setup_uses_genoio_minimum_maf_filter() -> None:
+    args = _common_setup_args("trans")
+    args.maf = 0.05
+
+    ready_data, _, _, _, _ = cli._common_setup(args, _LoggerStub())
+
+    assert ready_data.variant_filter.to_ir() == {
+        "op": "and",
+        "left": genoio.polymorphic().to_ir(),
+        "right": genoio.maf(min=0.05).to_ir(),
+    }
 
 
 def test_cli_help_exposes_dosage_genotype_mode() -> None:

--- a/tests/test_io/test_genoio_engine.py
+++ b/tests/test_io/test_genoio_engine.py
@@ -12,7 +12,12 @@ import pytest
 import jax
 import jax.numpy as jnp
 
-from jaxqtl.io._geno_engine import filter_sample_ids, GenotypeReadOptions, normalize_variant_info
+from jaxqtl.io._geno_engine import (
+    default_variant_filter,
+    filter_sample_ids,
+    GenotypeReadOptions,
+    normalize_variant_info,
+)
 from jaxqtl.io._pheno import ExpressionData
 from jaxqtl.map.data import align_on_iid, CisData, ReadyDataState
 
@@ -127,6 +132,16 @@ def test_filter_sample_ids_preserves_genoio_source_order_for_keep_and_drop() -> 
 
     assert filter_sample_ids(samples, keep=["iid3", "iid1"]) == ("iid1", "iid3")
     assert filter_sample_ids(samples, drop=["iid2", "iid4"]) == ("iid1", "iid3")
+
+
+def test_default_variant_filter_applies_minimum_maf() -> None:
+    observed = default_variant_filter(min_maf=0.05)
+
+    assert observed.to_ir() == {
+        "op": "and",
+        "left": genoio.polymorphic().to_ir(),
+        "right": genoio.maf(min=0.05).to_ir(),
+    }
 
 
 def test_normalize_variant_info_preserves_genoio_counted_allele_convention() -> None:


### PR DESCRIPTION
adds `--maf` flag to the CLI. Users can now provide `--maf 0.01` to have genotype (dosages or hardcalls) filtered on the fly.

Refs: https://github.com/mancusolab/jaxqtl/issues/19