### PR TITLE
fix(cli): fail on chromosome label mismatches

### DIFF
--- a/src/jaxqtl/cli.py
+++ b/src/jaxqtl/cli.py
@@ -450,6 +450,35 @@ def _load_genotype_data(args, log):
     raise ValueError("No valid genotype file specified.")
 
 
+def _unique_chromosome_labels(chromosomes: pl.Series) -> set[str]:
+    """Return unique chromosome labels after converting them to strings."""
+    return set(chromosomes.unique().cast(pl.Utf8).to_list())
+
+
+def _validate_chromosome_labels(expr_data, geno_data) -> None:
+    """Reject phenotype chromosome labels that are absent from genotype metadata."""
+    phenotype_chromosomes = _unique_chromosome_labels(expr_data.pheno_meta.get_column("chrom"))
+    genotype_chromosomes = _unique_chromosome_labels(geno_data.variants().get_column("chrom"))
+    phenotype_only = sorted(phenotype_chromosomes - genotype_chromosomes)
+    if not phenotype_only:
+        return
+
+    phenotype_labels = sorted(phenotype_chromosomes)
+    genotype_labels = sorted(genotype_chromosomes)
+    if phenotype_chromosomes.isdisjoint(genotype_chromosomes):
+        raise ValueError(
+            "No chromosome labels overlap between phenotype and genotype data. "
+            f"Phenotype labels: {phenotype_labels}; genotype labels: {genotype_labels}. "
+            "A chromosome naming mismatch (for example, 'Chr1' versus '1') may cause all genes to be skipped."
+        )
+    else:
+        raise ValueError(
+            "Phenotype chromosome labels absent from genotype data: "
+            f"{phenotype_only}. Genes on these chromosomes will be skipped. "
+            f"Phenotype labels: {phenotype_labels}; genotype labels: {genotype_labels}."
+        )
+
+
 def _common_setup(args, log):
     # Set up the distributional family and corresponding cumulative generating function (CGF) here.
     # We only use CGF if --spa is set, but may as well set up thin objects here so we don't need to re-enumerate
@@ -563,6 +592,8 @@ def _common_setup(args, log):
     expr_data = expr_data.filter_genes_by_percentage(args.min_gene_expr_pct)
     if args.min_indiv_expr_pct:
         expr_data = expr_data.filter_individuals_by_percentage(args.min_indiv_expr_pct)
+
+    _validate_chromosome_labels(expr_data, geno_data)
 
     covar = read_plink_style_tsvlike(args.covar, args.covar_name, args.rm_covar)
 

--- a/tests/test_cli/test_genoio_cli.py
+++ b/tests/test_cli/test_genoio_cli.py
@@ -57,6 +57,14 @@ class _EmptyGenoioDataset:
         )
 
 
+class _ChromosomeMetadataDataset:
+    def __init__(self, chromosomes: list[str]) -> None:
+        self._variants = pl.DataFrame({"chrom": chromosomes})
+
+    def variants(self) -> pl.DataFrame:
+        return self._variants
+
+
 class _LoadDatasetSpy:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
@@ -192,6 +200,33 @@ def test_deprecated_geno_raises_without_constructing_genoio(monkeypatch: pytest.
         cli._load_genotype_data(_args(geno="legacy-prefix"), _LoggerStub())
 
     assert spy.calls == []
+
+
+def test_unique_chromosome_labels_deduplicates_labels() -> None:
+    chromosomes = pl.Series("chrom", ["1", "1", "2"])
+
+    assert cli._unique_chromosome_labels(chromosomes) == {"1", "2"}
+
+
+def test_chromosome_mismatch_error_identifies_zero_overlap() -> None:
+    expression = SimpleNamespace(pheno_meta=pl.DataFrame({"chrom": ["Chr1"]}))
+    genotype = _ChromosomeMetadataDataset(["1"])
+
+    with pytest.raises(ValueError, match="No chromosome labels overlap") as exc_info:
+        cli._validate_chromosome_labels(expression, genotype)
+
+    assert "Chr1" in str(exc_info.value)
+    assert "1" in str(exc_info.value)
+
+
+def test_chromosome_mismatch_error_identifies_partial_overlap() -> None:
+    expression = SimpleNamespace(pheno_meta=pl.DataFrame({"chrom": ["1", "Chr2"]}))
+    genotype = _ChromosomeMetadataDataset(["1", "2"])
+
+    with pytest.raises(ValueError, match="Phenotype chromosome labels absent from genotype data") as exc_info:
+        cli._validate_chromosome_labels(expression, genotype)
+
+    assert "Chr2" in str(exc_info.value)
 
 
 def test_cli_help_marks_legacy_genotype_inputs() -> None:


### PR DESCRIPTION
CLI will now check for overlap of chromosome names between expression/phenotype data and genotype data. If no overlap is detected it will raise an error and back out early, before attempting analyses. 
Refs: https://github.com/mancusolab/jaxqtl/issues/34