### PR TITLE
fix(poisson): accept fractional responses

### DIFF
--- a/src/jaxqtl/distribution/_expfam.py
+++ b/src/jaxqtl/distribution/_expfam.py
@@ -15,7 +15,7 @@ import jax.random as rdm
 import jax.scipy.stats as jaxstats
 
 from jax import lax
-from jax.scipy.special import gammaln
+from jax.scipy.special import gammaln, xlogy
 from jaxtyping import Array, ArrayLike, ScalarLike
 
 from ._links import (
@@ -475,7 +475,11 @@ class Poisson(ExponentialFamily):
     ) -> Array:
         y = jnp.asarray(y)
         eta = jnp.asarray(eta)
-        logprob = jnp.sum(jaxstats.poisson.logpmf(y, self.glink.inverse(eta)))
+        mu = self.glink.inverse(eta)
+        # Fractional abundance estimates are valid inputs, so do not apply the integer-support check in JAX's PMF.
+        logprob = xlogy(y, mu) - gammaln(y + 1.0) - mu
+        logprob = jnp.where(y < 0.0, -jnp.inf, logprob)
+        logprob = jnp.sum(logprob)
         return -logprob
 
     def variance(self, mu: ArrayLike, disp: ScalarLike = 1.0) -> Array:

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -5,12 +5,24 @@ import jax.numpy as jnp
 import jax.random as rdm
 
 from jax import config
+from jax.scipy.special import gammaln, xlogy
 
 from jaxqtl.distribution._expfam import Binomial, Gamma, Gaussian, NegativeBinomial, Poisson
 from jaxqtl.distribution._links import IdentityLink, InverseLink, LogitLink, LogLink, NBLink, PowerLink
 
 
 config.update("jax_enable_x64", True)
+
+
+def test_poisson_negloglikelihood_accepts_fractional_response():
+    y = jnp.asarray([0.0, 1.5, 3.25])
+    mu = jnp.asarray([1.0, 2.0, 4.0])
+
+    actual = Poisson().negloglikelihood(jnp.empty((y.size, 0)), y, jnp.log(mu), 1.0)
+    expected = jnp.sum(mu - xlogy(y, mu) + gammaln(y + 1.0))
+
+    assert jnp.isfinite(actual)
+    assert float(actual) == pytest.approx(float(expected))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
previously, if a fractional value was evaluated under a poisson likelihood, it would return -inf, breaking downstream inference. Probabilistic expression quantification (eg salmon) can produce fractional counts. This updated the log likelihood to use a custom implementation, rather than `jax.scipy.stats.poisson.logpmf` that doesn't check for integer values. 