### PR TITLE
refactor(io): drop qtl runtime dependency (#43)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "optimistix",
     "genoio>=0.1.0",
     "polars",
-    "qtl",
     "pyarrow",
     "rich-argparse>=1.8.0",
 ]
@@ -68,6 +67,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "statsmodels",
+  "qtl",
   "ruff>=0.0.243",
   "ty>=0.0.44",
 ]

--- a/src/jaxqtl/io/_normalization.py
+++ b/src/jaxqtl/io/_normalization.py
@@ -1,0 +1,111 @@
+# pattern: Functional Core
+
+"""JAX-native expression normalization kernels."""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from jax.scipy import stats as jsp_stats
+
+
+def _as_inexact_array(values: Any) -> jax.Array:
+    array = jnp.asarray(values)
+    if not jnp.issubdtype(array.dtype, jnp.inexact):
+        return array.astype(jnp.float32)
+    return array
+
+
+def edger_calcnormfactors(
+    counts: Any,
+    ref: int | None = None,
+    logratio_trim: float = 0.3,
+    sum_trim: float = 0.05,
+    acutoff: float = -1e10,
+) -> jax.Array:
+    """Calculate edgeR-style TMM scaling factors for a gene-by-sample matrix."""
+    counts_array = _as_inexact_array(counts)
+    library_sizes = jnp.sum(counts_array, axis=0)
+    normalized_counts = counts_array / library_sizes
+
+    if ref is None:
+        upper_quartiles = jnp.percentile(normalized_counts, 75.0, axis=0)
+        reference_index = jnp.argmin(jnp.abs(upper_quartiles - jnp.mean(upper_quartiles)))
+    else:
+        reference_index = jnp.asarray(ref)
+
+    reference_profile = normalized_counts[:, reference_index]
+    log_ratios = jnp.log2(normalized_counts / reference_profile[:, None])
+    average_log_expression = 0.5 * (jnp.log2(normalized_counts) + jnp.log2(reference_profile)[:, None])
+    variances = (library_sizes - counts_array) / (library_sizes * counts_array)
+    variances = variances + variances[:, reference_index, None]
+
+    def factor_for_sample(
+        log_ratios_column: jax.Array,
+        average_log_expression_column: jax.Array,
+        variances_column: jax.Array,
+    ) -> jax.Array:
+        finite = (
+            jnp.isfinite(log_ratios_column)
+            & jnp.isfinite(average_log_expression_column)
+            & (average_log_expression_column > acutoff)
+        )
+        n_finite = jnp.sum(finite)
+
+        def nonempty_factor(_: None) -> jax.Array:
+            ranked_log_ratios = jsp_stats.rankdata(
+                jnp.where(finite, log_ratios_column, jnp.inf),
+                method="average",
+            )
+            ranked_expression = jsp_stats.rankdata(
+                jnp.where(finite, average_log_expression_column, jnp.inf),
+                method="average",
+            )
+            n_finite_float = n_finite.astype(counts_array.dtype)
+            lower_log_ratio = jnp.floor(n_finite_float * logratio_trim) + 1.0
+            upper_log_ratio = n_finite_float + 1.0 - lower_log_ratio
+            lower_expression = jnp.floor(n_finite_float * sum_trim) + 1.0
+            upper_expression = n_finite_float + 1.0 - lower_expression
+            keep = (
+                finite
+                & (ranked_log_ratios >= lower_log_ratio)
+                & (ranked_log_ratios <= upper_log_ratio)
+                & (ranked_expression >= lower_expression)
+                & (ranked_expression <= upper_expression)
+            )
+            numerator = jnp.sum(jnp.where(keep, log_ratios_column / variances_column, 0.0))
+            denominator = jnp.sum(jnp.where(keep, 1.0 / variances_column, 0.0))
+            safe_denominator = jnp.where(denominator > 0.0, denominator, 1.0)
+            return jnp.where(denominator > 0.0, 2.0 ** (numerator / safe_denominator), 1.0)
+
+        return jax.lax.cond(
+            n_finite > 0,
+            nonempty_factor,
+            lambda _: jnp.array(1.0, dtype=counts_array.dtype),
+            operand=None,
+        )
+
+    factors = jax.vmap(factor_for_sample, in_axes=1)(log_ratios, average_log_expression, variances)
+    return factors / jnp.exp(jnp.mean(jnp.log(factors)))
+
+
+def edger_cpm(
+    counts: Any,
+    tmm: jax.Array | None = None,
+    normalized_lib_sizes: bool = True,
+) -> jax.Array:
+    """Return edgeR-style TMM-normalized counts per million."""
+    counts_array = _as_inexact_array(counts)
+    library_sizes = jnp.sum(counts_array, axis=0)
+    if normalized_lib_sizes:
+        factors = edger_calcnormfactors(counts_array) if tmm is None else _as_inexact_array(tmm)
+        library_sizes = library_sizes * factors
+    return counts_array / library_sizes * 1e6
+
+
+def inverse_normal_transform(values: Any) -> jax.Array:
+    """Apply a rank-based inverse-normal transform along the final axis."""
+    values_array = _as_inexact_array(values)
+    ranks = jsp_stats.rankdata(values_array, axis=-1, method="average")
+    return jsp_stats.norm.ppf(ranks / (values_array.shape[-1] + 1))

--- a/src/jaxqtl/io/_normalization.py
+++ b/src/jaxqtl/io/_normalization.py
@@ -24,7 +24,36 @@ def edger_calcnormfactors(
     sum_trim: float = 0.05,
     acutoff: float = -1e10,
 ) -> jax.Array:
-    """Calculate edgeR-style TMM scaling factors for a gene-by-sample matrix."""
+    r"""Calculate edgeR-style TMM scaling factors for a gene-by-sample count matrix.
+
+    TMM (trimmed mean of M-values) estimates a sample-specific scaling factor
+    from finite log-ratios and average log-expression values. The returned
+    factors have geometric mean one. This is the normalization-factor step used
+    by [`edger_cpm`][].
+
+    **Arguments:**
+
+    - `counts`: Nonnegative count matrix with shape `(g, n)`, where rows are
+      genes and columns are samples. Each sample must have a positive library
+      size. Remove genes with zero counts in every sample before calling this
+      function.
+    - `ref`: Optional zero-based reference-sample column. If `None`, select the
+      sample whose upper-quartile normalized expression is closest to the mean.
+    - `logratio_trim`: Fraction trimmed from each tail of the log-ratio ranks.
+    - `sum_trim`: Fraction trimmed from each tail of the average-expression
+      ranks.
+    - `acutoff`: Minimum average log-expression retained for factor estimation.
+
+    **Returns:**
+
+    A floating-point JAX array with shape `(n,)` containing one TMM factor per
+    sample.
+
+    **Failure Modes:**
+
+    A sample with zero total counts produces nonfinite values. Invalid count
+    values, such as negative counts or NaNs, can also produce nonfinite factors.
+    """
     counts_array = _as_inexact_array(counts)
     library_sizes = jnp.sum(counts_array, axis=0)
     normalized_counts = counts_array / library_sizes
@@ -95,7 +124,27 @@ def edger_cpm(
     tmm: jax.Array | None = None,
     normalized_lib_sizes: bool = True,
 ) -> jax.Array:
-    """Return edgeR-style TMM-normalized counts per million."""
+    r"""Return edgeR-style TMM-normalized counts per million.
+
+    The effective library size is the column sum of `counts` multiplied by its
+    TMM factor. Set `normalized_lib_sizes=False` to use unadjusted library sizes.
+
+    **Arguments:**
+
+    - `counts`: Nonnegative gene-by-sample count matrix with shape `(g, n)`.
+    - `tmm`: Optional TMM factors with shape `(n,)`. If `None`, factors are
+      calculated from `counts` with [`edger_calcnormfactors`][].
+    - `normalized_lib_sizes`: Whether to apply TMM factors to library sizes.
+
+    **Returns:**
+
+    A floating-point JAX array with shape `(g, n)` of counts per million.
+
+    **Failure Modes:**
+
+    A zero effective library size produces nonfinite values. Rows with zero
+    counts in every sample should be removed before factor estimation.
+    """
     counts_array = _as_inexact_array(counts)
     library_sizes = jnp.sum(counts_array, axis=0)
     if normalized_lib_sizes:
@@ -105,7 +154,21 @@ def edger_cpm(
 
 
 def inverse_normal_transform(values: Any) -> jax.Array:
-    """Apply a rank-based inverse-normal transform along the final axis."""
+    r"""Apply a rank-based inverse-normal transform along the final axis.
+
+    Ties receive their average rank. Each rank is scaled by $n + 1$, where $n$
+    is the length of the final axis, then transformed with the standard-normal
+    quantile function.
+
+    **Arguments:**
+
+    - `values`: Floating-point or integer array. For an expression matrix with
+      shape `(g, n)`, rows are transformed independently across the `n` samples.
+
+    **Returns:**
+
+    A floating-point JAX array with the same shape as `values`.
+    """
     values_array = _as_inexact_array(values)
     ranks = jsp_stats.rankdata(values_array, axis=-1, method="average")
     return jsp_stats.norm.ppf(ranks / (values_array.shape[-1] + 1))

--- a/src/jaxqtl/io/_pheno.py
+++ b/src/jaxqtl/io/_pheno.py
@@ -8,16 +8,14 @@ from typing import Literal
 
 import numpy as np
 import polars as pl
-import qtl.io
-import qtl.norm
 
 import equinox as eqx
 import jax
 
 from jax import numpy as jnp
-from jax.scipy import stats as jsp_stats
 from jaxtyping import Array, PRNGKeyArray
 
+from ._normalization import edger_cpm, inverse_normal_transform
 from ._utils import validate_user_columns
 
 
@@ -198,8 +196,6 @@ class ExpressionData:
 
         if transform == "tmm":
             raise NotImplementedError("'tmm' transform not implemented yet.")
-            tmm_counts_df = edger_cpm(pheno, normalized_lib_sizes=True)
-            pheno = inverse_normal_transform(tmm_counts_df)
         elif transform == "log1p":
             pheno = jnp.log1p(pheno)  # prevent log(0)
 
@@ -378,13 +374,8 @@ def bed_transform_y(pheno_path: str | PathLike[str], method: str = "log1p"):
     if method == "log1p":
         count_df = count_df.with_columns([pl.col(name).log1p().alias(name) for name in expr_cols])
     elif method == "tmm":
-        # use edger TMM method to calculate size factor and convert to counts per million
-        tmm_counts = qtl.norm.edger_cpm(
-            count_df.select(pl.col(expr_cols)).to_numpy(),
-            normalized_lib_sizes=True,
-        )
-        # inverse normal transformation on each gene (row)
-        norm_df = np.asarray(qtl.norm.inverse_normal_transform(tmm_counts))
+        tmm_counts = edger_cpm(count_df.select(pl.col(expr_cols)).to_numpy())
+        norm_df = np.asarray(inverse_normal_transform(tmm_counts))
         if norm_df.shape[0] == count_df.height:
             count_df = count_df.with_columns([pl.Series(name, norm_df[:, i]) for i, name in enumerate(expr_cols)])
         else:
@@ -393,148 +384,6 @@ def bed_transform_y(pheno_path: str | PathLike[str], method: str = "log1p"):
         raise ValueError(f"Unsupported mode {method}")
 
     return count_df
-
-
-def edger_cpm(counts_df, tmm=None, normalized_lib_sizes=True):
-    """
-    Return edgeR normalized/rescaled CPM (counts per million)
-
-    Reproduces edgeR::cpm.DGEList
-    """
-    lib_size = counts_df.sum(axis=0)
-    if normalized_lib_sizes:
-        if tmm is None:
-            tmm = edger_calcnormfactors(counts_df)
-        lib_size = lib_size * tmm
-    return counts_df / lib_size * 1e6
-
-
-def edger_calcnormfactors(
-    counts,
-    ref=None,
-    logratio_trim=0.3,
-    sum_trim=0.05,
-    acutoff=-1e10,
-):
-    """
-    JAX version of edgeR::calcNormFactors.default (TMM normalization).
-
-    Parameters
-    ----------
-    counts : array-like, shape (G, S)
-        Count matrix (genes x samples). Typically counts_df.values.
-    ref : int or None
-        Reference sample index. If None, chosen as in edgeR.
-    logratio_trim : float
-        Proportion to trim from M-values (log fold change).
-    sum_trim : float
-        Proportion to trim from A-values (average log expression).
-    acutoff : float
-        Minimum A-value.
-    verbose : bool
-        If True, print reference index (host-side, not jitted).
-
-    Returns
-    -------
-    tmm : jax.numpy.ndarray, shape (S,)
-        TMM normalization factors.
-    """
-    Y = jnp.asarray(counts, dtype=jnp.float32)  # shape (G, S)
-    G, ns = Y.shape
-
-    # library sizes
-    N = jnp.sum(Y, axis=0)  # shape (S,)
-
-    # select reference sample if not given
-    if ref is None:
-        Y_norm_tmp = Y / N
-        f75 = jnp.percentile(Y_norm_tmp, 75.0, axis=0)  # shape (S,)
-        dev = jnp.abs(f75 - jnp.mean(f75))
-        ref = int(jnp.argmin(dev))
-
-    # normalized counts and reference column
-    Y_norm = Y / N
-    ref_profile = Y[:, ref] / N[ref]  # shape (G,)
-
-    # log fold change (M) and average log expression (A)
-    logR = jnp.log2(Y_norm / ref_profile[:, None])  # shape (G, S)
-    logYnorm = jnp.log2(Y_norm)
-    log_ref = jnp.log2(ref_profile)
-    absE = 0.5 * (logYnorm + log_ref[:, None])  # shape (G, S)
-
-    # weights v (w in paper)
-    v = (N - Y) / (N * Y)  # shape (G, S)
-    v = v + v[:, ref][:, None]  # v_i + v_ref
-
-    def tmm_for_sample(logR_col, absE_col, v_col):
-        """
-        Compute TMM factor for a single sample (column).
-        logR_col, absE_col, v_col: shape (G,)
-        """
-        # finite & above A cutoff
-        fin = jnp.isfinite(logR_col) & jnp.isfinite(absE_col) & (absE_col > acutoff)
-
-        n = jnp.sum(fin)  # number of "valid" genes
-
-        def nonempty_case(args):
-            logR_col, absE_col, v_col, fin, n = args
-
-            # Use NaNs to tell rankdata which entries to ignore
-            logR_for_rank = jnp.where(fin, logR_col, jnp.nan)
-            absE_for_rank = jnp.where(fin, absE_col, jnp.nan)
-
-            rankR = jsp_stats.rankdata(
-                logR_for_rank,
-                method="average",
-                axis=None,
-                nan_policy="omit",
-            )
-            rankE = jsp_stats.rankdata(
-                absE_for_rank,
-                method="average",
-                axis=None,
-                nan_policy="omit",
-            )
-
-            n_f = n.astype(jnp.float32)
-
-            loL = jnp.floor(n_f * logratio_trim) + 1.0
-            hiL = n_f + 1.0 - loL
-            loS = jnp.floor(n_f * sum_trim) + 1.0
-            hiS = n_f + 1.0 - loS
-
-            keep = fin & (rankR >= loL) & (rankR <= hiL) & (rankE >= loS) & (rankE <= hiS)
-
-            w = v_col  # variance term; paper has a known typo about 1/v
-
-            num = jnp.nansum(jnp.where(keep, logR_col / w, 0.0))
-            den = jnp.nansum(jnp.where(keep, 1.0 / w, 0.0))
-
-            # guard against den == 0
-            tmm_val = jnp.where(den > 0.0, 2.0 ** (num / den), 1.0)
-            return tmm_val
-
-        # if no valid genes for this column, just return 1.0
-        tmm_val = jax.lax.cond(
-            n > 0,
-            nonempty_case,
-            lambda _: jnp.array(1.0, dtype=jnp.float32),
-            (logR_col, absE_col, v_col, fin, n),
-        )
-        return tmm_val
-
-    # vectorize over columns (samples)
-    tmm = jax.vmap(tmm_for_sample, in_axes=1)(logR, absE, v)  # shape (S,)
-
-    # center normalization factors to have geometric mean 1
-    tmm = tmm / jnp.exp(jnp.mean(jnp.log(tmm)))
-    return tmm
-
-
-def inverse_normal_transform(pheno):
-    """Apply inverse normal transform across observations."""
-    r = jsp_stats.rankdata(pheno)
-    return jsp_stats.norm.ppf(r / (pheno.shape[0] + 1))
 
 
 @partial(jax.jit, static_argnums=(2, 3, 4))

--- a/src/jaxqtl/io/_pheno.py
+++ b/src/jaxqtl/io/_pheno.py
@@ -352,8 +352,28 @@ class ExpressionData:
 
 
 def bed_transform_y(pheno_path: str | PathLike[str], method: str = "log1p"):
-    """Perform transformation on gene expression count matrix
-    count_df: rows are genes, columns are individual ID
+    r"""Transform expression values in a BED-style count matrix.
+
+    The input's first four columns are preserved as feature metadata. Remaining
+    columns are sample counts. Genes with zero counts across every sample are
+    removed before transformation.
+
+    **Arguments:**
+
+    - `pheno_path`: Path to a tab-delimited BED-style matrix with four metadata
+      columns followed by one count column per sample.
+    - `method`: `"log1p"` applies `log(1 + count)` independently to each count.
+      `"tmm"` applies TMM-normalized CPM followed by a row-wise inverse-normal
+      transform across samples.
+
+    **Returns:**
+
+    A Polars frame containing the retained metadata columns and transformed
+    sample-expression columns.
+
+    **Raises:**
+
+    - `ValueError`: If `method` is not `"log1p"` or `"tmm"`.
     """
     count_df = pl.read_csv(
         str(pheno_path),

--- a/tests/test_io/test_pheno.py
+++ b/tests/test_io/test_pheno.py
@@ -3,9 +3,15 @@
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import polars as pl
 import pytest
+import qtl.norm
 
+import jax
+import jax.numpy as jnp
+
+from jaxqtl.io._normalization import edger_cpm, inverse_normal_transform
 from jaxqtl.io._pheno import bed_transform_y, ExpressionData
 
 
@@ -62,32 +68,40 @@ def test_bed_transform_y_log1p_filters_zero_rows_and_transforms_columns(tmp_path
     np.testing.assert_allclose(out["s2"].to_numpy(), np.log1p(np.array([1.0, 5.0])))
 
 
-def test_bed_transform_y_tmm_applies_external_transforms(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_jax_normalization_matches_qtl_norm_under_jit() -> None:
+    counts = np.array(
+        [
+            [0.0, 20.0, 30.0],
+            [100.0, 120.0, 80.0],
+            [5.0, 7.0, 11.0],
+            [60.0, 45.0, 90.0],
+            [25.0, 35.0, 20.0],
+            [40.0, 50.0, 65.0],
+        ]
+    )
+    expected_cpm = qtl.norm.edger_cpm(pd.DataFrame(counts), normalized_lib_sizes=True)
+    expected = np.asarray(qtl.norm.inverse_normal_transform(expected_cpm))
+
+    actual_cpm = jax.jit(edger_cpm)(jnp.asarray(counts))
+    actual = jax.jit(inverse_normal_transform)(actual_cpm)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_bed_transform_y_tmm_matches_qtl_norm(tmp_path: Path) -> None:
     path = _write_bed(
         tmp_path,
         "#Chr\tstart\tend\tgene\ts1\ts2\nX\t10\t20\tgene1\t1\t2\nX\t30\t40\tgene2\t0\t0\nX\t50\t60\tgene3\t3\t4\n",
     )
-    captured: dict[str, np.ndarray] = {}
-
-    def fake_edger_cpm(counts, normalized_lib_sizes=True):
-        captured["counts"] = np.asarray(counts)
-        return captured["counts"] * 2
-
-    def fake_inverse_normal_transform(counts):
-        counts_array = np.asarray(counts)
-        # make output deterministic and row order-preserving
-        return np.arange(counts_array.size, dtype=float).reshape(counts_array.shape)
-
-    monkeypatch.setattr("jaxqtl.io._pheno.qtl.norm.edger_cpm", fake_edger_cpm)
-    monkeypatch.setattr("jaxqtl.io._pheno.qtl.norm.inverse_normal_transform", fake_inverse_normal_transform)
-
     out = bed_transform_y(path, method="tmm")
 
     assert out.height == 2
-    assert captured["counts"].shape == (2, 2)
-    np.testing.assert_allclose(captured["counts"], np.array([[1.0, 2.0], [3.0, 4.0]]))
-    np.testing.assert_allclose(out["s1"].to_numpy(), np.array([0.0, 2.0]))
-    np.testing.assert_allclose(out["s2"].to_numpy(), np.array([1.0, 3.0]))
+    expected_cpm = qtl.norm.edger_cpm(
+        pd.DataFrame(np.array([[1.0, 2.0], [3.0, 4.0]])),
+        normalized_lib_sizes=True,
+    )
+    expected = np.asarray(qtl.norm.inverse_normal_transform(expected_cpm))
+    np.testing.assert_allclose(out[["s1", "s2"]].to_numpy(), expected, rtol=1e-5, atol=1e-5)
 
 
 def test_bed_transform_y_unsupported_mode_raises_error(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,6 @@ dependencies = [
     { name = "optimistix" },
     { name = "polars" },
     { name = "pyarrow" },
-    { name = "qtl" },
     { name = "rich-argparse" },
 ]
 
@@ -466,6 +465,7 @@ dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "qtl" },
     { name = "ruff" },
     { name = "statsmodels" },
     { name = "ty" },
@@ -491,7 +491,7 @@ requires-dist = [
     { name = "pyarrow" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "qtl" },
+    { name = "qtl", marker = "extra == 'dev'" },
     { name = "rich-argparse", specifier = ">=1.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.243" },
     { name = "statsmodels", marker = "extra == 'dev'" },


### PR DESCRIPTION
This PR addresses #43 . We depended on qtl only for normalization functions, which were themselves ported from R packages. Here we port the numpy implementations to JAX-based implementations. qtl is only required for dev to serve as an oracle in the unit tests covering the newer jax implementation.